### PR TITLE
fix julia-v0.5 deprecation warnings

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -27,6 +27,6 @@ provides(BuildProcess, Autotools(libtarget="src/liberfa.la"), erfa)
 #     -static-libgcc src/*.c
 # 7za a erfa-win64.7z usr
 
-provides(Binaries, URI("https://bintray.com/artifact/download/kbarbary/generic/erfa-win$(WORD_SIZE).7z"), erfa, os = :Windows)
+provides(Binaries, URI("https://bintray.com/artifact/download/kbarbary/generic/erfa-win$(Sys.WORD_SIZE).7z"), erfa, os = :Windows)
 
 @BinDeps.install @compat Dict(:liberfa => :liberfa)

--- a/src/ERFA.jl
+++ b/src/ERFA.jl
@@ -1,6 +1,7 @@
 module ERFA
 
 using Compat
+import Compat.String
 import Base.getindex
 
 export
@@ -707,7 +708,7 @@ function eraDat(iy::Integer, im::Integer, id::Integer, fd::Real)
     d[1]
 end
 
-function eraD2dtf(scale::ByteString, ndp::Integer, d1::Real, d2::Real)
+function eraD2dtf(scale::String, ndp::Integer, d1::Real, d2::Real)
     iy = Int32[0]
     imo = Int32[0]
     id = Int32[0]
@@ -719,7 +720,7 @@ function eraD2dtf(scale::ByteString, ndp::Integer, d1::Real, d2::Real)
     iy[1], imo[1], id[1], ihmsf[1], ihmsf[2], ihmsf[3], ihmsf[4]
 end
 
-function eraDtf2d(scale::ByteString, iy::Integer, imo::Integer, id::Integer, ih::Integer, imi::Integer, sec::Real)
+function eraDtf2d(scale::String, iy::Integer, imo::Integer, id::Integer, ih::Integer, imi::Integer, sec::Real)
     r1 = [0.]
     r2 = [0.]
     i = ccall((:eraDtf2d,liberfa), Cint,


### PR DESCRIPTION
Only two small fixes: one for the now-deprecated `ByteString` and one for `Base.WORD_SIZE` in the build script.