### PR TITLE
add new functions from liberfa and bump to version 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
 julia:
   - nightly
+  - 0.5
   - 0.4
-  - 0.3
 notifications:
   email: false
 script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 BinDeps
 Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -29,6 +29,6 @@ provides(BuildProcess, Autotools(libtarget="src/liberfa.la"), erfa)
 #     -static-libgcc src/*.c
 # 7za a erfa-win64.7z usr
 
-provides(Binaries, URI("https://bintray.com/artifact/download/kbarbary/generic/erfa-win$(Sys.WORD_SIZE).7z"), erfa, os = :Windows)
+provides(Binaries, URI("https://dl.bintray.com/kbarbary/generic/erfa-$(version)-win$(Sys.WORD_SIZE).7z"), erfa, os = :Windows)
 
 @BinDeps.install @compat Dict(:liberfa => :liberfa)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using BinDeps
 using Compat
 @BinDeps.setup
 
-version = "1.2.0"
+version = "1.3.0"
 url = "https://github.com/liberfa/erfa/releases/download/v$version/erfa-$version.tar.gz"
 
 # This function returns true if a library satisfies our
@@ -10,7 +10,9 @@ url = "https://github.com/liberfa/erfa/releases/download/v$version/erfa-$version
 # the dlopen'ed handle. We test is certain symbols we need exist.
 validate(l, h) = (Libdl.dlsym_e(h, "eraAb") != C_NULL &&
                   Libdl.dlsym_e(h, "eraG2icrs") != C_NULL &&
-                  Libdl.dlsym_e(h, "eraIcrs2g") != C_NULL)
+                  Libdl.dlsym_e(h, "eraIcrs2g") != C_NULL &&
+                  Libdl.dlsym_e(h, "eraEceq06") != C_NULL &&
+                  Libdl.dlsym_e(h, "eraLtpb") != C_NULL)
 
 erfa = library_dependency("liberfa"; validate = validate)
 

--- a/src/ERFA.jl
+++ b/src/ERFA.jl
@@ -97,6 +97,8 @@ export
     eraD2tf,
     eraDtdb,
     eraDtf2d,
+    eraEceq06,
+    eraEcm06,
     eraEe00,
     eraEe00a,
     eraEe00b,
@@ -110,6 +112,7 @@ export
     eraEpj,
     eraEpj2jd,
     eraEpv00,
+    eraEqec06,
     eraEqeq94,
     eraEra00,
     eraFad03,
@@ -153,6 +156,13 @@ export
     eraLd,
     eraLdn,
     eraLdsun,
+    eraLteceq,
+    eraLtecm,
+    eraLteqec,
+    eraLtp,
+    eraLtpb,
+    eraLtpecl,
+    eraLtpequ,
     eraNum00a,
     eraNum00b,
     eraNum06a,
@@ -1393,6 +1403,7 @@ end
 for f in (:eraC2i00a,
           :eraC2i00b,
           :eraC2i06a,
+          :eraEcm06,
           :eraNum00a,
           :eraNum00b,
           :eraNum06a,
@@ -1693,6 +1704,61 @@ for f in (:eraXys00a,
                   (Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),
                   date1,date2,x,y,s)
             x[1], y[1], s[1]
+        end
+    end
+end
+
+for f in (:eraLtecm,
+          :eraLtp,
+          :eraLtpb)
+    @eval begin
+        function ($f)(epj::Cdouble)
+            rp = zeros((3,3))
+            ccall(($(Expr(:quote,f)),liberfa), Void,
+                  (Cdouble,Ptr{Cdouble}),
+                  epj,rp)
+            rp
+        end
+    end
+end
+
+for f in (:eraLtpecl,
+          :eraLtpequ)
+    @eval begin
+        function ($f)(epj::Cdouble)
+            vec = zeros(3)
+            ccall(($(Expr(:quote,f)),liberfa), Void,
+                  (Cdouble,Ptr{Cdouble}),
+                  epj,vec)
+            vec
+        end
+    end
+end
+
+for f in (:eraEceq06,
+          :eraEqec06)
+    @eval begin
+        function ($f)(date1::Cdouble,date2::Cdouble,d1::Cdouble,d2::Cdouble)
+            r1 = [0.0]
+            r2 = [0.0]
+            ccall(($(Expr(:quote,f)),liberfa), Void,
+                  (Cdouble,Cdouble,Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble}),
+                  date1, date2, d1, d2, r1,r2)
+            r1[1], r2[1]
+        end
+    end
+end
+
+for f in (:eraLteceq,
+          :eraLteqec)
+    @eval begin
+        function ($f)(epj::Cdouble,d1::Cdouble,d2::Cdouble)
+            r1 = [0.0]
+            r2 = [0.0]
+            ccall(($(Expr(:quote,f)),liberfa), Void,
+                  (Cdouble,Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble}),
+                  epj, d1, d2, r1,r2)
+            r1[1], r2[1]
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2500,3 +2500,83 @@ dl, db = eraIcrs2g(5.9338074302227188048671087,-1.1784870613579944551540570)
 dr, dd = eraG2icrs(5.5850536063818546461558105, -0.7853981633974483096156608)
 @test_approx_eq_eps dr 5.9338074302227188048671 1e-14
 @test_approx_eq_eps dd -1.1784870613579944551541 1e14
+
+# eraLtp
+rp = eraLtp(1666.666)
+@test_approx_eq_eps rp[1] 0.9967044141159213819 1e-14
+@test_approx_eq_eps rp[2] 0.7437801893193210840e-1 1e-14
+@test_approx_eq_eps rp[3] 0.3237624409345603401e-1 1e-14
+@test_approx_eq_eps rp[4] -0.7437802731819618167e-1 1e-14
+@test_approx_eq_eps rp[5] 0.9972293894454533070 1e-14
+@test_approx_eq_eps rp[6] -0.1205768842723593346e-2 1e-14
+@test_approx_eq_eps rp[7] -0.3237622482766575399e-1 1e-14
+@test_approx_eq_eps rp[8] -0.1206286039697609008e-2 1e-14
+@test_approx_eq_eps rp[9] 0.9994750246704010914 1e-14
+
+# eraLtpb
+rp = eraLtpb(1666.666)
+@test_approx_eq_eps rp[1] 0.9967044167723271851 1e-14
+@test_approx_eq_eps rp[2] 0.7437794731203340345e-1 1e-14
+@test_approx_eq_eps rp[3] 0.3237632684841625547e-1 1e-14
+@test_approx_eq_eps rp[4] -0.7437795663437177152e-1 1e-14
+@test_approx_eq_eps rp[5] 0.9972293947500013666 1e-14
+@test_approx_eq_eps rp[6] -0.1205741865911243235e-2 1e-14
+@test_approx_eq_eps rp[7] -0.3237630543224664992e-1 1e-14
+@test_approx_eq_eps rp[8] -0.1206316791076485295e-2  1e-14
+@test_approx_eq_eps rp[9] 0.9994750220222438819 1e-14
+
+# eraLtpecl
+vec = eraLtpecl(-1500.0)
+@test_approx_eq_eps vec[1] 0.4768625676477096525e-3 1e-14
+@test_approx_eq_eps vec[2] -0.4052259533091875112 1e-14
+@test_approx_eq_eps vec[3] 0.9142164401096448012 1e-14
+
+# eraLtpequ
+vec = eraLtpequ(-2500.0)
+@test_approx_eq_eps vec[1] -0.3586652560237326659 1e-14
+@test_approx_eq_eps vec[2] -0.1996978910771128475 1e-14
+@test_approx_eq_eps vec[3] 0.9118552442250819624 1e-14
+
+# eraEceq06
+dr, dd = eraEceq06(2456165.5,0.401182685,5.1,-0.9)
+@test_approx_eq_eps dr 5.533459733613627767 1e-14
+@test_approx_eq_eps dd -1.246542932554480576 1e-14
+
+# eraEqec06
+dl, db = eraEqec06(1234.5,2440000.5,1.234,0.987)
+@test_approx_eq_eps dl 1.342509918994654619 1e-14
+@test_approx_eq_eps db 0.5926215259704608132 1e-14
+
+# eraEcm06
+rm = eraEcm06(2456165.5,0.401182685)
+@test_approx_eq_eps rm[1] 0.9999952427708701137 1e-14
+@test_approx_eq_eps rm[2] -0.2829062057663042347e-2 1e-14
+@test_approx_eq_eps rm[3] -0.1229163741100017629e-2 1e-14
+@test_approx_eq_eps rm[4] 0.3084546876908653562e-2 1e-14
+@test_approx_eq_eps rm[5] 0.9174891871550392514 1e-14
+@test_approx_eq_eps rm[6] 0.3977487611849338124 1e-14
+@test_approx_eq_eps rm[7] 0.2488512951527405928e-5 1e-14
+@test_approx_eq_eps rm[8] -0.3977506604161195467 1e-14
+@test_approx_eq_eps rm[9] 0.9174935488232863071 1e-14
+
+# eraLtecm
+rm = eraLtecm(-3000.0)
+@test_approx_eq_eps rm[1] 0.3564105644859788825 1e-14
+@test_approx_eq_eps rm[2] 0.8530575738617682284 1e-14
+@test_approx_eq_eps rm[3] 0.3811355207795060435 1e-14
+@test_approx_eq_eps rm[4] -0.9343283469640709942 1e-14
+@test_approx_eq_eps rm[5] 0.3247830597681745976 1e-14
+@test_approx_eq_eps rm[6] 0.1467872751535940865 1e-14
+@test_approx_eq_eps rm[7] 0.1431636191201167793e-2 1e-14
+@test_approx_eq_eps rm[8] -0.4084222566960599342 1e-14
+@test_approx_eq_eps rm[9] 0.9127919865189030899 1e-14
+
+# eraLteceq
+dr, dd = eraLteceq(2500.0,1.5,0.6)
+@test_approx_eq_eps dr 1.275156021861921167 1e-14
+@test_approx_eq_eps dd 0.9966573543519204791 1e-14
+
+# eraLteqec
+dl, db = eraLteqec(-1500.0,1.234,0.987)
+@test_approx_eq_eps dl 0.5039483649047114859 1e-14
+@test_approx_eq_eps db 0.5848534459726224882 1e-14


### PR DESCRIPTION
those patches add new functions from liberfa-1.3.0, and their respective tests. @kbarbary can you, please, build and check for the windows binaries? and also update appveyor.yml.