### PR TITLE
Do not require Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.4
 BinDeps 0.3.21
-Compat 0.7.10

--- a/src/ERFA.jl
+++ b/src/ERFA.jl
@@ -1,7 +1,5 @@
 module ERFA
 
-using Compat
-import Compat.String
 import Base.getindex
 
 export
@@ -718,7 +716,7 @@ function eraDat(iy::Integer, im::Integer, id::Integer, fd::Real)
     d[1]
 end
 
-function eraD2dtf(scale::String, ndp::Integer, d1::Real, d2::Real)
+function eraD2dtf(scale::AbstractString, ndp::Integer, d1::Real, d2::Real)
     iy = Int32[0]
     imo = Int32[0]
     id = Int32[0]
@@ -730,7 +728,7 @@ function eraD2dtf(scale::String, ndp::Integer, d1::Real, d2::Real)
     iy[1], imo[1], id[1], ihmsf[1], ihmsf[2], ihmsf[3], ihmsf[4]
 end
 
-function eraDtf2d(scale::String, iy::Integer, imo::Integer, id::Integer, ih::Integer, imi::Integer, sec::Real)
+function eraDtf2d(scale::AbstractString, iy::Integer, imo::Integer, id::Integer, ih::Integer, imi::Integer, sec::Real)
     r1 = [0.]
     r2 = [0.]
     i = ccall((:eraDtf2d,liberfa), Cint,


### PR DESCRIPTION
As suggested by @nirinA in #28, there is no more need of `Compat` package.