### PR TITLE
0.7 Compatibility - Fix out-of-sync tests and deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.41.1
+Compat 0.61.1
 BinaryProvider 0.3.0

--- a/src/ERFA.jl
+++ b/src/ERFA.jl
@@ -9,8 +9,7 @@ else
     error("ERFA is not properly installed. Please run Pkg.build(\"ERFA\")")
 end
 
-using Compat: @warn, Cvoid
-using Compat.Unicode: ucfirst
+using Compat: @warn, Cvoid, uppercasefirst
 
 include("erfa_common.jl")
 include("deprecated.jl")

--- a/src/a.jl
+++ b/src/a.jl
@@ -305,7 +305,7 @@ parts of the astrometric transformation chain.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: unchanged
     - `xpl`: unchanged
@@ -419,7 +419,7 @@ parts of the astrometric transformation chain.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: unchanged
     - `xpl`: unchanged
@@ -547,7 +547,7 @@ site coordinates.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -703,7 +703,7 @@ parts of the ICRS/CIRS transformations.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -876,7 +876,7 @@ astrometric transformation chain.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: unchanged
     - `xpl`: unchanged
@@ -1002,7 +1002,7 @@ astrometric transformation chain.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: unchanged
     - `xpl`: unchanged
@@ -1708,7 +1708,7 @@ can be used instead.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -1783,7 +1783,7 @@ used.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -1886,7 +1886,7 @@ proper motion is eraAtciq.
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -2195,7 +2195,7 @@ or eraApcs[13].
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -2264,7 +2264,7 @@ or eraApcs[13].
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -2508,7 +2508,7 @@ calling eraApio[13] or eraApco[13].
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -2912,7 +2912,7 @@ calling eraApio[13] or eraApco[13].
     - `eh`: Sun to observer (unit vector)
     - `em`: Distance from Sun to observer (au)
     - `v`: Barycentric observer velocity (vector, c)
-    - `bm1`: ``\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
+    - `bm1`: ``\\sqrt{1-|v|^2}`` Reciprocal of Lorenz factor
     - `bpn`: Bias-precession-nutation matrix
     - `along`: Longitude + s' (radians)
     - `xp1`: Polar motion xp wrt local meridian (radians)
@@ -3021,7 +3021,7 @@ anpm
 for name in ("anp",
              "anpm")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a)
             ccall(($fc, liberfa), Cdouble, (Cdouble,), a)
@@ -3140,7 +3140,7 @@ a2tf
 for name in ("a2af",
              "a2tf")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(ndp, a)
             s = Ref{Cchar}('+')

--- a/src/b.jl
+++ b/src/b.jl
@@ -233,7 +233,7 @@ bp06
 for name in ("bp00",
              "bp06")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             rb = zeros((3, 3))

--- a/src/c.jl
+++ b/src/c.jl
@@ -273,7 +273,7 @@ c2teqx
 for name in ("c2tcio",
              "c2teqx")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(rc2i, era, rpom)
             rc2t = zeros((3, 3))
@@ -514,7 +514,7 @@ for name in ("c2t00a",
              "c2t00b",
              "c2t06a")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(tta, ttb, uta, utb, xp, yp)
             rc2t = zeros((3, 3))
@@ -693,7 +693,7 @@ c2txy
 for name in ("c2tpe",
              "c2txy")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(tta, ttb, uta, utb, x, y, xp, yp)
             rc2t = zeros((3, 3))
@@ -913,7 +913,7 @@ for name in ("c2i00a",
              "c2i00b",
              "c2i06a")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             r = zeros((3, 3))

--- a/src/e.jl
+++ b/src/e.jl
@@ -310,7 +310,7 @@ eqec06
 for name in ("eceq06",
              "eqec06")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(date1, date2, d1, d2)
             r1 = [0.0]
@@ -382,7 +382,7 @@ epj2jd
 for name in ("epb2jd",
              "epj2jd")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(d)
             r1 = Ref(0.0)
@@ -904,7 +904,7 @@ for name in ("ee00a",
              "eqeq94",
              "era00")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d1, d2) = ccall(($fc, liberfa), Cdouble, (Cdouble, Cdouble), d1, d2)
 end
 

--- a/src/f.jl
+++ b/src/f.jl
@@ -674,7 +674,7 @@ for name in ("fad03",
              "faur03",
              "fave03")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d) = ccall(($fc, liberfa), Cdouble, (Cdouble,), d)
 end
 

--- a/src/g.jl
+++ b/src/g.jl
@@ -525,7 +525,7 @@ for name in ("gmst82",
              "gst00b",
              "gst94")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d1, d2) = ccall(($fc, liberfa), Cdouble, (Cdouble, Cdouble), d1, d2)
 end
 
@@ -801,7 +801,7 @@ for name in ("gmst00",
              "gst00a",
              "gst06a")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d1, d2, t1, t2) = ccall(($fc, liberfa), Cdouble, (Cdouble, Cdouble, Cdouble, Cdouble), d1, d2, t1, t2)
 end
 

--- a/src/l.jl
+++ b/src/l.jl
@@ -363,7 +363,7 @@ for name in ("ltecm",
              "ltp",
              "ltpb")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(epj)
             rp = zeros((3, 3))
@@ -454,7 +454,7 @@ ltpequ
 for name in ("ltpecl",
              "ltpequ")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(epj)
             vec = zeros(3)
@@ -576,7 +576,7 @@ lteqec
 for name in ("lteceq",
              "lteqec")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(epj, d1, d2)
             r1 = [0.0]

--- a/src/n.jl
+++ b/src/n.jl
@@ -450,7 +450,7 @@ for name in ("nut00a",
              "nut06a",
              "nut80")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             r1 = Ref(0.0)
@@ -680,7 +680,7 @@ for name in ("num00a",
              "num06a",
              "nutm80")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             r = zeros((3, 3))

--- a/src/o.jl
+++ b/src/o.jl
@@ -91,6 +91,6 @@ obl80
 for name in ("obl06",
              "obl80")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d1, d2) = ccall(($fc, liberfa), Cdouble, (Cdouble, Cdouble), d1, d2)
 end

--- a/src/p.jl
+++ b/src/p.jl
@@ -1427,7 +1427,7 @@ pn06
 for name in ("pn00",
              "pn06")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(date1, date2, dpsi, deps)
             epsa = Ref(0.0)
@@ -1514,7 +1514,7 @@ for name in ("pmp",
              "ppp",
              "pxp")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             ab = zeros(3)
@@ -1615,7 +1615,7 @@ for name in ("pvmpv",
              "pvppv",
              "pvxpv")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             ab = zeros((2, 3))
@@ -1906,7 +1906,7 @@ for name in ("pn00a",
              "pn00b",
              "pn06a")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(date1, date2)
             dpsi = Ref(0.0)
@@ -2007,7 +2007,7 @@ p-vector inner (=scalar=dot) product.
 
 ### Returned ###
 
-- ``a \cdot b``
+- ``a \\cdot b``
 
 """
 pdp
@@ -2015,7 +2015,7 @@ pdp
 for name in ("pap",
              "pdp")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             ccall(($fc, liberfa), Cdouble, (Ptr{Cdouble}, Ptr{Cdouble}), a, b)
@@ -2502,7 +2502,7 @@ for name in ("pmat00",
              "pnm06a",
              "pnm80")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             r = zeros((3, 3))

--- a/src/r.jl
+++ b/src/r.jl
@@ -349,7 +349,7 @@ for name in ("rx",
              "ry",
              "rz")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, r)
             ccall(($fc, liberfa), Cvoid,

--- a/src/s.jl
+++ b/src/s.jl
@@ -740,7 +740,7 @@ for name in ("s00a",
              "s06a",
              "sp00")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d1, d2) = ccall(($fc, liberfa), Cdouble, (Cdouble, Cdouble), d1, d2)
 end
 
@@ -902,6 +902,6 @@ s06
 for name in ("s00",
              "s06")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval ($f)(d1, d2, t1, t2) = ccall(($fc, liberfa), Cdouble, (Cdouble, Cdouble, Cdouble, Cdouble), d1, d2, t1, t2)
 end

--- a/src/t.jl
+++ b/src/t.jl
@@ -248,7 +248,7 @@ for name in ("taiut1",
              "tttdb",
              "ttut1")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b, c)
             r1 = Ref(0.0)
@@ -542,7 +542,7 @@ for name in ("taitt",
              "tttai",
              "tttcg")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b)
             r1 = Ref(0.0)
@@ -617,7 +617,7 @@ tf2d
 for name in ("tf2a",
              "tf2d")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(s, ideg, iamin, asec)
             rad = Ref(0.0)

--- a/src/u.jl
+++ b/src/u.jl
@@ -187,7 +187,7 @@ for name in ("ut1tai",
              "ut1utc",
              "utcut1")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(a, b, c)
             r1 = Ref(0.0)

--- a/src/x.jl
+++ b/src/x.jl
@@ -280,7 +280,7 @@ for name in ("xys00a",
              "xys00b",
              "xys06a")
     f = Symbol(name)
-    fc = "era" * ucfirst(name)
+    fc = "era" * uppercasefirst(name)
     @eval begin
         function ($f)(date1, date2)
             x = Ref(0.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using ERFA
 
 using Compat.Test
 
-# @testset "ERFA" begin
+@testset "ERFA" begin
     # @testset "Calendar Tools" begin
         u1, u2 = ERFA.dtf2d("UTC", 2010, 7, 24, 11, 18, 7.318)
         a1, a2 = ERFA.utctai(u1, u2)
@@ -93,10 +93,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.4110930268679817955, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.1782189004872870264, atol = 1e-12)
         @test isapprox(astrom.em, 1.010465295811013146, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.4289638897813379954e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], 0.8115034021720941898e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], 0.3517555123437237778e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999951686013336, atol = 1e-15)
+        @test isapprox(astrom.v[1], 0.4289638913597693554e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], 0.8115034051581320575e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], 0.3517555136380563427e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999951686012981, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 1.0, atol = 1e-10)
         @test isapprox(astrom.bpn[4], 0.0, atol = 1e-10)
         @test isapprox(astrom.bpn[7], 0.0, atol = 1e-10)
@@ -121,10 +121,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.4110930268331896318, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.1782189006019749850, atol = 1e-12)
         @test isapprox(astrom.em, 1.010465295964664178, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.4289638897157027528e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], 0.8115034002544663526e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], 0.3517555122593144633e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999951686013498, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.4289638912941341125e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], 0.8115034032405042132e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], 0.3517555135536470279e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999951686013142, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 1.0, atol = 1e-10)
         @test isapprox(astrom.bpn[4], 0.0, atol = 1e-10)
         @test isapprox(astrom.bpn[7], 0.0, atol = 1e-10)
@@ -155,10 +155,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.4110930268679817955, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.1782189004872870264, atol = 1e-12)
         @test isapprox(astrom.em, 1.010465295811013146, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.4289638897813379954e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], 0.8115034021720941898e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], 0.3517555123437237778e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999951686013336, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.4289638913597693554e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], 0.8115034051581320575e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], 0.3517555136380563427e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999951686012981, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 0.9999991390295159156, atol = 1e-12)
         @test isapprox(astrom.bpn[4], 0.4978650072505016932e-7, atol = 1e-12)
         @test isapprox(astrom.bpn[7], 0.1312227200000000000e-2, atol = 1e-12)
@@ -183,10 +183,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.4110930268331896318, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.1782189006019749850, atol = 1e-12)
         @test isapprox(astrom.em, 1.010465295964664178, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.4289638897157027528e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], 0.8115034002544663526e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], 0.3517555122593144633e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999951686013498, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.4289638912941341125e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], 0.8115034032405042132e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], 0.3517555135536470279e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999951686013142, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 0.9999992060376761710, atol = 1e-12)
         @test isapprox(astrom.bpn[4], 0.4124244860106037157e-7, atol = 1e-12)
         @test isapprox(astrom.bpn[7], 0.1260128571051709670e-2, atol = 1e-12)
@@ -227,10 +227,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.2092452125848862201, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.09075578152261439954, atol = 1e-12)
         @test isapprox(astrom.em, 0.9998233241710617934, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.2078704985147609823e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], -0.8955360074407552709e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], -0.3863338980073114703e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999950277561600, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.2078704992916728762e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], -0.8955360107151952319e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], -0.3863338994288951082e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999950277561236, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 0.9999991390295159156, atol = 1e-12)
         @test isapprox(astrom.bpn[4], 0.4978650072505016932e-7, atol = 1e-12)
         @test isapprox(astrom.bpn[7], 0.1312227200000000000e-2, atol = 1e-12)
@@ -275,10 +275,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.2092452121602867431, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.09075578153903832650, atol = 1e-12)
         @test isapprox(astrom.em, 0.9998233240914558422, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.2078704986751370303e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], -0.8955360100494469232e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], -0.3863338978840051024e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999950277561368, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.2078704994520489246e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], -0.8955360133238868938e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], -0.3863338993055887398e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999950277561004, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 0.9999991390295147999, atol = 1e-12)
         @test isapprox(astrom.bpn[4], 0.4978650075315529277e-7, atol = 1e-12)
         @test isapprox(astrom.bpn[7], 0.001312227200850293372, atol = 1e-12)
@@ -318,10 +318,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.2092452125849967195, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.09075578152266466572, atol = 1e-12)
         @test isapprox(astrom.em, 0.9998233241710457140, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.2078704985513566571e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], -0.8955360074245006073e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], -0.3863338980073572719e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999950277561601, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.2078704993282685510e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], -0.8955360106989405683e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], -0.3863338994289409097e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999950277561237, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 1, atol = 1e-10)
         @test isapprox(astrom.bpn[4], 0, atol = 1e-10)
         @test isapprox(astrom.bpn[7], 0, atol = 1e-10)
@@ -348,10 +348,10 @@ using Compat.Test
         @test isapprox(astrom.eh[2], -0.4111053891734599955, atol = 1e-12)
         @test isapprox(astrom.eh[3], -0.1782336880637689334, atol = 1e-12)
         @test isapprox(astrom.em, 1.010428384373318379, atol = 1e-12)
-        @test isapprox(astrom.v[1], 0.4279877278327626511e-4, atol = 1e-16)
-        @test isapprox(astrom.v[2], 0.7963255057040027770e-4, atol = 1e-16)
-        @test isapprox(astrom.v[3], 0.3517564000441374759e-4, atol = 1e-16)
-        @test isapprox(astrom.bm1, 0.9999999952947981330, atol = 1e-12)
+        @test isapprox(astrom.v[1], 0.4279877294121697570e-4, atol = 1e-16)
+        @test isapprox(astrom.v[2], 0.7963255087052120678e-4, atol = 1e-16)
+        @test isapprox(astrom.v[3], 0.3517564013384691531e-4, atol = 1e-16)
+        @test isapprox(astrom.bm1, 0.9999999952947980978, atol = 1e-12)
         @test isapprox(astrom.bpn[1], 1, atol = 1e-10)
         @test isapprox(astrom.bpn[4], 0, atol = 1e-10)
         @test isapprox(astrom.bpn[7], 0, atol = 1e-10)
@@ -1836,11 +1836,11 @@ using Compat.Test
         ep2b = 51544.5
         ra2, dec2, pmr2, pmd2, px2, rv2 = ERFA.pmsafe(ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b)
         @test isapprox(ra2, 1.234087484501017061, atol = 1e-12)
-        @test isapprox(dec2, 0.7888249982450468574, atol = 1e-12)
+        @test isapprox(dec2, 0.7888249982450468567, atol = 1e-12)
         @test isapprox(pmr2, 0.9996457663586073988e-5, atol = 1e-12)
-        @test isapprox(pmd2, -0.2000040085106737816e-4, atol = 1e-16)
-        @test isapprox(px2, 0.9999997295356765185e-2, atol = 1e-12)
-        @test isapprox(rv2, 10.38468380113917014, atol = 1e-10)
+        @test isapprox(pmd2, -0.2000040085106754565e-4, atol = 1e-16)
+        @test isapprox(px2, 0.9999997295356830666e-2, atol = 1e-12)
+        @test isapprox(rv2, 10.38468380293920069, atol = 1e-10)
     # end
 
     # ERFA.pmat00
@@ -2351,10 +2351,10 @@ using Compat.Test
         ra, dec, pmr, pmd, px, rv = ERFA.pvstar(pv)
         @test isapprox(ra, 0.1686756e-1, atol = 1e-12)
         @test isapprox(dec, -1.093989828, atol = 1e-12)
-        @test isapprox(pmr, -0.178323516e-4, atol = 1e-16)
-        @test isapprox(pmd, 0.2336024047e-5, atol = 1e-16)
+        @test isapprox(pmr, -0.1783235160000472788e-4, atol = 1e-16)
+        @test isapprox(pmd, 0.2336024047000619347e-5, atol = 1e-16)
         @test isapprox(px, 0.74723, atol = 1e-12)
-        @test isapprox(rv, -21.6, atol = 1e-11)
+        @test isapprox(rv, -21.60000010107306010, atol = 1e-11)
     # end
 
     # ERFA.pvtob
@@ -2651,12 +2651,12 @@ using Compat.Test
         rv1 = -21.6
         ra2, dec2, pmr2, pmd2, px2, rv2 = ERFA.starpm(ra1, dec1, pmr1, pmd1, px1, rv1,
                                                       2400000.5, 50083.0, 2400000.5, 53736.0)
-        @test isapprox(ra2, 0.01668919069414242368, atol = 1e-13)
-        @test isapprox(dec2, -1.093966454217127879, atol = 1e-13)
-        @test isapprox(pmr2, -0.1783662682155932702e-4, atol = 1e-17)
-        @test isapprox(pmd2, 0.2338092915987603664e-5, atol = 1e-17)
-        @test isapprox(px2, 0.7473533835323493644, atol = 1e-13)
-        @test isapprox(rv2, -21.59905170476860786, atol = 1e-11)
+        @test isapprox(ra2, 0.01668919069414256149, atol = 1e-13)
+        @test isapprox(dec2, -1.093966454217127897, atol = 1e-13)
+        @test isapprox(pmr2, -0.1783662682153176524e-4, atol = 1e-17)
+        @test isapprox(pmd2, 0.2338092915983989595e-5, atol = 1e-17)
+        @test isapprox(px2, 0.7473533835317719243, atol = 1e-13)
+        @test isapprox(rv2, -21.59905170476417175, atol = 1e-11)
     # end
 
     # ERFA.starpv
@@ -2671,9 +2671,9 @@ using Compat.Test
         @test isapprox(pv[1], 126668.5912743160601, atol = 1e-10)
         @test isapprox(pv[2], 2136.792716839935195, atol = 1e-12)
         @test isapprox(pv[3], -245251.2339876830091, atol = 1e-10)
-        @test isapprox(pv[4], -0.4051854035740712739e-2, atol = 1e-13)
-        @test isapprox(pv[5], -0.6253919754866173866e-2, atol = 1e-15)
-        @test isapprox(pv[6], 0.1189353719774107189e-1, atol = 1e-13)
+        @test isapprox(pv[4], -0.4051854008955659551e-2, atol = 1e-13)
+        @test isapprox(pv[5], -0.6253919754414777970e-2, atol = 1e-15)
+        @test isapprox(pv[6], 0.1189353714588109341e-1, atol = 1e-13)
     # end
 
     # ERFA.sxp
@@ -3012,5 +3012,4 @@ using Compat.Test
         @test isapprox(dl, 0.5039483649047114859, atol = 1e-14)
         @test isapprox(db, 0.5848534459726224882, atol = 1e-14)
     # end
-# end
-
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using ERFA
 
 using Compat.Test
 
-@testset "ERFA" begin
+# @testset "ERFA" begin
     # @testset "Calendar Tools" begin
         u1, u2 = ERFA.dtf2d("UTC", 2010, 7, 24, 11, 18, 7.318)
         a1, a2 = ERFA.utctai(u1, u2)
@@ -3012,4 +3012,4 @@ using Compat.Test
         @test isapprox(dl, 0.5039483649047114859, atol = 1e-14)
         @test isapprox(db, 0.5848534459726224882, atol = 1e-14)
     # end
-end
+# end


### PR DESCRIPTION
Some tests were failing because the reference values were out of sync with the original ERFA source. No idea why they did not throw on 0.6 🤷‍♂️ 