### PR TITLE
Convert arguments of `sepp` to `Vector{Float64}`

### DIFF
--- a/src/s.jl
+++ b/src/s.jl
@@ -490,7 +490,8 @@ Angular separation between two p-vectors.
 """
 function sepp(a, b)
     @checkdims 3 a b
-    ccall((:eraSepp, liberfa), Cdouble, (Ptr{Cdouble}, Ptr{Cdouble}), a, b)
+    ccall((:eraSepp, liberfa), Cdouble, (Ptr{Cdouble}, Ptr{Cdouble}),
+          convert(Vector{Float64},a), convert(Vector{Float64}, b))
 end
 
 """

--- a/test/s.jl
+++ b/test/s.jl
@@ -71,9 +71,20 @@ end
 
 @testset "sepp" begin
     a = [1.,0.1,0.2]
+    i = [10,1,2]
     b = [-3.,1e-3,0.2]
+    ab = [1.,-3.,0.1,1e-3,0.2,0.2]
+    expected_s = 2.860391919024660768
     s = sepp(a, b)
-    @test s ≈ 2.860391919024660768 atol=1e-12
+    @test s ≈ expected_s atol=1e-12
+    s = sepp(i, b)
+    @test s ≈ expected_s atol=1e-12
+    s = sepp(b, i)
+    @test s ≈ expected_s atol=1e-12
+    s = sepp(ab[1:2:5], ab[2:2:6])
+    @test s ≈ expected_s atol=1e-12
+    s = @views sepp(ab[1:2:5], ab[2:2:6])
+    @test s ≈ expected_s atol=1e-12
     @test_throws ArgumentError sepp(a[1:2], b)
     @test_throws ArgumentError sepp(a, b[1:2])
 end


### PR DESCRIPTION
The first of these two commits adds tests that expose the bug described in #63.  The second of these two commits fixes the bug.